### PR TITLE
added job_attach method for attachments shown in visitor view

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -20,6 +20,7 @@ Response = (function () {
     this._platform = platform
     this._store = {}
     this._headers = {}
+    this._attachments = []
     this._http_headers = []
     this._context = context
   }
@@ -42,6 +43,20 @@ Response = (function () {
     if (data) {
       this._respond(data)
     }
+  }
+  Response.prototype.job_attach = function (...attachments) {
+    const requiredLabels = [ 'type', 'label', 'value' ]
+    const allowedTypes = [ 'link', 'password' ]
+    for (const attachment of attachments) {
+      if (!~requiredLabels.every(l => ~Object.keys(attachment).indexOf(l))) {
+        throw new Error(`Attachment requires mandatory properties ${requiredLabels.join(', ')}`)
+      }
+      if (!~allowedTypes.indexOf(attachment.type)) {
+        throw new Error(`Attachment must be of one of the following types ${allowedTypes.join(', ')}`)
+      }
+    }
+    this._attachments.push(...attachments)
+    this.meta('set_job_attachments', JSON.stringify(this._attachments))
   }
   Response.prototype.job_ignore = function (status, data) {
     this.meta('set_job_status', 'ignored')


### PR DESCRIPTION
https://envoycom.atlassian.net/browse/PLUG-263

Context: the purpose of this PR is to add the ability to add attachments for event handlers. The first two attachment types are
- link - for displaying a link to a website or file. Will be first used in NDA plugins
- password - for displaying a password. It will first be used by Wifi plugins.

The attachments will initially be displayed on the right side of the visitor screen.