### PR TITLE
remove type restriction for job attach method

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -46,13 +46,9 @@ Response = (function () {
   }
   Response.prototype.job_attach = function (...attachments) {
     const requiredLabels = [ 'type', 'label', 'value' ]
-    const allowedTypes = [ 'link', 'password' ]
     for (const attachment of attachments) {
       if (!~requiredLabels.every(l => ~Object.keys(attachment).indexOf(l))) {
         throw new Error(`Attachment requires mandatory properties ${requiredLabels.join(', ')}`)
-      }
-      if (!~allowedTypes.indexOf(attachment.type)) {
-        throw new Error(`Attachment must be of one of the following types ${allowedTypes.join(', ')}`)
       }
     }
     this._attachments.push(...attachments)


### PR DESCRIPTION
Removing the `type` restriction for the job attach method, because it seems like an unnecessary restriction. for example, the wifi plugins need to be able to communicate 'username' for example, and we've chosen to represent that as an attachment with `type: username`. rather than add each one individually, i think it's okay to remove the restriction.