### PR TITLE
changed logger to output to stdout insteadof stderr

### DIFF
--- a/helpers/logger.js
+++ b/helpers/logger.js
@@ -2,5 +2,7 @@ const debug = require('debug')
 const info = debug('envoy-plugin:info')
 const warn = debug('envoy-plugin:warn')
 const error = debug('envoy-plugin:error')
-
+info.log = console.log.bind(console)
+warn.log = console.log.bind(console)
+error.log = console.log.bind(console)
 module.exports = { info, warn, error }


### PR DESCRIPTION
Currently the logger helper outputs logs to sderr instead of stdout. This is a problem because aws lambda doesn't display sderr in the stored log.