### PR TITLE
add plugin_fail method on res to set the plugin status to failed whil…

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -77,6 +77,10 @@ Response = (function () {
       this._respond(errorToObject(data))
     }
   }
+  Response.prototype.plugin_fail = function (status, msg, data) {
+    this.meta('set_install_status', 'failed')
+    this.job_fail(status, msg, data)
+  }
   Response.prototype.succeed = function (data) {
     this._respond(data || {})
   }


### PR DESCRIPTION
…e failing the job as well

took a stab at this change @carolshark let me know if this works. i figured why not reuse the `job_fail` method as a `plugin_fail` implies a `job_fail`

lmk what you think of the method name too. wasn't sure what the best way to name it is.