### PR TITLE
Adding edge case to number formatter

### DIFF
--- a/lib/twilioHelper.js
+++ b/lib/twilioHelper.js
@@ -18,6 +18,9 @@ function makeInternational (phoneNumber, countryCode) {
   if (!phoneNumber) {
     return null
   }
+  if (`${phoneNumber}`.startsWith('+')) { // the number is already fully-formatted, so don't coerce a country code
+    countryCode = undefined
+  }
   try {
     const parsed = phone.parsePhoneNumber(phoneNumber, countryCode ? countryCode.toUpperCase() : undefined)
     if (parsed.isPossible()) {

--- a/test/twilioHelper.spec.js
+++ b/test/twilioHelper.spec.js
@@ -115,6 +115,32 @@ describe('twilioHelper | send', function () {
     let ret = await this.subject(req, { message: 'Hello World' })
     expect(ret).to.equal('No valid phone number provided')
   })
+  it('should not fail if country is available and number is internationally formatted with a different country', async function () {
+    this.twilioSendStub.resolves('Sent')
+    let req = {
+      location: {
+        attributes: {
+          country: 'cz'
+        }
+      },
+      body: {
+        attributes: {
+          'user-data': [{
+            field: 'Phone number special',
+            value: '+5165825765'
+          }]
+        }
+      }
+    }
+
+    let ret = await this.subject(req, { message: 'Hello World' })
+    expect(ret).to.equal('Sent')
+    expect(this.twilioSendStub).to.have.been.calledWith({
+      body: 'Hello World',
+      from: '000000000',
+      to: '+5165825765'
+    })
+  })
   it('should return twilio errors', async function () {
     let notSentError = new Error('Not Sent')
     this.twilioSendStub.rejects(notSentError)


### PR DESCRIPTION
If a user enters a fully-formatted phone number, we should not use the location's country code. 

E.g. if the location is in the US and the customer enters a fully-formatted UK number, we should not force the US country code, or an invalid number may result.