### PR TITLE
Added support for storage items

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -9,10 +9,7 @@ Request = (function () {
       this[x] = src.request_meta[x]
     }
     this.payload = this.body = src.request_body
-    this.storage = (this.install.plugin_storage_items || []).reduce((storage, item) => {
-      storage[item.key] = item.value
-      return storage
-    }, {})
+    this.storage = this.install.storage || {}
   }
   return Request
 })()

--- a/lib/request.js
+++ b/lib/request.js
@@ -9,6 +9,10 @@ Request = (function () {
       this[x] = src.request_meta[x]
     }
     this.payload = this.body = src.request_body
+    this.storage = (this.install.plugin_storage_items || []).reduce((storage, item) => {
+      storage[item.key] = item.value
+      return storage
+    }, {})
   }
   return Request
 })()

--- a/lib/response.js
+++ b/lib/response.js
@@ -107,6 +107,12 @@ Response = (function () {
   Response.prototype.meta = function (header, value) {
     this._headers[header] = value
   }
+  Response.prototype._queue_storage_update = function (action, key, args = {}) {
+    if (key.startsWith('_')) {
+      throw new Error('Keys cannot start with an underscore.')
+    }
+    this._storage_updates.push(Object.assign({ action, key }, args))
+  }
   Response.prototype.storage_set = function (key, value) {
     this._queue_storage_update('set', key, { value })
   }
@@ -115,12 +121,6 @@ Response = (function () {
   }
   Response.prototype.storage_set_unique = function (key, options = {}) {
     this._queue_storage_update('set_unique', key, options)
-  }
-  Response.prototype._queue_storage_update = function (action, key, args = {}) {
-    if (key.startsWith('_')) {
-      throw new Error('Keys cannot start with an underscore.')
-    }
-    this._storage_updates.push(Object.assign(args, { action, key }))
   }
   Response.prototype._respond = function (data, status, method = 'succeed') {
     logger.info(this._platform.getLoggingSignature(), 'Response._respond', `method=${method}`, `status=${status}`, `data:`, data)

--- a/lib/response.js
+++ b/lib/response.js
@@ -108,10 +108,19 @@ Response = (function () {
     this._headers[header] = value
   }
   Response.prototype.storage_set = function (key, value) {
-    this._storage_updates.push({ action: 'set', key, value })
+    this._queue_storage_update('set', key, { value })
   }
   Response.prototype.storage_unset = function (key) {
-    this._storage_updates.push({ action: 'unset', key })
+    this._queue_storage_update('unset', key)
+  }
+  Response.prototype.storage_set_unique = function (key, options = {}) {
+    this._queue_storage_update('set_unique', key, options)
+  }
+  Response.prototype._queue_storage_update = function (action, key, args = {}) {
+    if (key.startsWith('_')) {
+      throw new Error('Keys cannot start with an underscore.')
+    }
+    this._storage_updates.push(Object.assign(args, { action, key }))
   }
   Response.prototype._respond = function (data, status, method = 'succeed') {
     logger.info(this._platform.getLoggingSignature(), 'Response._respond', `method=${method}`, `status=${status}`, `data:`, data)

--- a/lib/response.js
+++ b/lib/response.js
@@ -22,6 +22,7 @@ Response = (function () {
     this._headers = {}
     this._attachments = []
     this._http_headers = []
+    this._storage_updates = []
     this._context = context
   }
   Response.prototype.error = function (error) {
@@ -106,6 +107,12 @@ Response = (function () {
   Response.prototype.meta = function (header, value) {
     this._headers[header] = value
   }
+  Response.prototype.storage_set = function (key, value) {
+    this._storage_updates.push({ action: 'set', key, value })
+  }
+  Response.prototype.storage_unset = function (key) {
+    this._storage_updates.push({ action: 'unset', key })
+  }
   Response.prototype._respond = function (data, status, method = 'succeed') {
     logger.info(this._platform.getLoggingSignature(), 'Response._respond', `method=${method}`, `status=${status}`, `data:`, data)
     let out = { meta: {}, body: null }
@@ -116,6 +123,7 @@ Response = (function () {
     if (Object.keys(this._store).find(x => Object.keys(this._store[x]).length)) {
       out.meta.store = this._store
     }
+    out.meta.storage_updates = this._storage_updates
     Object.assign(out.meta, this._headers)
     if (this._http_headers.length) {
       out.meta.headers = this._http_headers

--- a/lib/response.js
+++ b/lib/response.js
@@ -108,9 +108,6 @@ Response = (function () {
     this._headers[header] = value
   }
   Response.prototype._queue_storage_update = function (action, key, args = {}) {
-    if (key.startsWith('_')) {
-      throw new Error('Keys cannot start with an underscore.')
-    }
     this._storage_updates.push(Object.assign({ action, key }, args))
   }
   Response.prototype.storage_set = function (key, value) {

--- a/test/request.spec.js
+++ b/test/request.spec.js
@@ -1,0 +1,30 @@
+const { expect } = require('chai')
+const Request = require('../lib/request')
+
+describe('request', function () {
+  it('should set the storage property if storage items are present', function () {
+    const src = {
+      plugin_install: {
+        plugin_storage_items: [
+          {
+            key: 'foo',
+            value: 'bar'
+          },
+          {
+            key: 'a',
+            value: 'b'
+          }
+        ]
+      }
+    }
+    const req = new Request({}, src, {})
+    expect(req.storage).to.deep.equal({ foo: 'bar', a: 'b' })
+  })
+  it('should still have the property set if no storage items are present', function () {
+    const src = {
+      plugin_install: {}
+    }
+    const req = new Request({}, src, {})
+    expect(req.storage).to.deep.equal({})
+  })
+})

--- a/test/request.spec.js
+++ b/test/request.spec.js
@@ -5,16 +5,10 @@ describe('request', function () {
   it('should set the storage property if storage items are present', function () {
     const src = {
       plugin_install: {
-        plugin_storage_items: [
-          {
-            key: 'foo',
-            value: 'bar'
-          },
-          {
-            key: 'a',
-            value: 'b'
-          }
-        ]
+        storage: {
+          foo: 'bar',
+          a: 'b'
+        }
       }
     }
     const req = new Request({}, src, {})

--- a/test/response.js
+++ b/test/response.js
@@ -1,0 +1,29 @@
+const { expect } = require('chai')
+const Response = require('../lib/response')
+
+describe('response', function () {
+  describe('res.storage_set and res.storage_unset', function () {
+    it('sets an array of ordered commands on the output meta', function () {
+      let out = {}
+      const context = {
+        succeed: toOut => {
+          out = toOut
+        }
+      }
+      const res = new Response({ getLoggingSignature: () => {} }, context)
+      res.storage_set('foo', 'bar')
+      res.storage_set('a', { b: 'c' })
+      res.storage_unset('baz')
+      res.storage_set('bool', false)
+      res.storage_unset('bat')
+      res._respond()
+      expect(out.meta.storage_updates).to.deep.equal([
+        { action: 'set', key: 'foo', value: 'bar' },
+        { action: 'set', key: 'a', value: { b: 'c' } },
+        { action: 'unset', key: 'baz' },
+        { action: 'set', key: 'bool', value: false },
+        { action: 'unset', key: 'bat' }
+      ])
+    })
+  })
+})

--- a/test/response.js
+++ b/test/response.js
@@ -16,13 +16,19 @@ describe('response', function () {
       res.storage_unset('baz')
       res.storage_set('bool', false)
       res.storage_unset('bat')
+      res.storage_set_unique('something')
+      res.storage_set_unique('with_chars', { chars: 'abcdefg' })
+      res.storage_set_unique('with_size', { size: 3 })
       res._respond()
       expect(out.meta.storage_updates).to.deep.equal([
         { action: 'set', key: 'foo', value: 'bar' },
         { action: 'set', key: 'a', value: { b: 'c' } },
         { action: 'unset', key: 'baz' },
         { action: 'set', key: 'bool', value: false },
-        { action: 'unset', key: 'bat' }
+        { action: 'unset', key: 'bat' },
+        { action: 'set_unique', key: 'something' },
+        { action: 'set_unique', key: 'with_chars', chars: 'abcdefg' },
+        { action: 'set_unique', key: 'with_size', size: 3 }
       ])
     })
   })


### PR DESCRIPTION
We're adding a `req.storage` property, to access existing storage items as a single object.

You can issue `set` and `unset` commands to persist to the database using:
`res.storage_set(key, value)` and `res.storage_unset(key)`

[Link to proposal](https://docs.google.com/document/d/1Fs5FSMxg4_XYymHcPDYwdUxPVTtiXOWlxk1WqyJYXn0/edit#)

[Related Envoy Web changes](https://github.com/envoy/envoy-web/pull/8001)